### PR TITLE
Add SUT: grubba

### DIFF
--- a/sut/grubba.conf
+++ b/sut/grubba.conf
@@ -1,0 +1,18 @@
+agent_id: grubba
+server_address: http://10.245.128.10:8000
+global_timeout: 172800
+output_timeout: 43200
+
+execution_basedir: /data/testflinger-agent/tests/grubba/run
+logging_basedir: /data/testflinger-agent/tests/grubba/logs
+results_basedir: /data/testflinger-agent/tests/grubba/results
+logging_level: INFO
+# logging_quiet: True
+job_queues:
+   - grubba
+
+setup_command: echo Setup
+provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 /data/snappy-device-agents/snappy-device-agent noprovision provision -c /data/snappy-device-agents/sut/grubba_snappy.yaml testflinger.json"
+test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 /data/snappy-device-agents/snappy-device-agent noprovision runtest -c /data/snappy-device-agents/sut/grubba_snappy.yaml testflinger.json"
+reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 /data/snappy-device-agents/snappy-device-agent noprovision reserve -c /data/snappy-device-agents/sut/grubba_snappy.yaml testflinger.json"
+cleanup_command: echo Cleanup

--- a/sut/grubba.yaml
+++ b/sut/grubba.yaml
@@ -1,0 +1,6 @@
+job_queue: grubba
+provision_data:
+  distro: jammy
+test_data:
+  test_cmds: |
+    ssh -o StrictHostKeyChecking=no ubuntu@$DEVICE_IP ifconfig

--- a/sut/grubba_snappy.yaml
+++ b/sut/grubba_snappy.yaml
@@ -1,0 +1,8 @@
+device_ip: 10.229.48.48
+node_id: d0eff0
+node_name: grubba
+maas_user: testflinger_a
+agent_name: grubba
+env:
+    HEXR_DEVICE_SECURE_ID: J3B4uh2fEFhRZGLJUE9Gtm
+    DEVICE_IP: 10.229.48.48


### PR DESCRIPTION
Trying to add Grubba device:
https://certification.canonical.com/hardware/202308-31932/
https://barometz.admin.canonical.com/equipment/grubba

I don't know the rule for how to fill the node_id, so I just took the last part of the sha256sum of the sut/grubba_snappy.yaml file... but this is not used in other SUTs